### PR TITLE
Develop/lnxdsp 547 u boot elf image gets rejected by cces elfloader

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi.bb
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi.bb
@@ -37,7 +37,9 @@ do_install () {
 }
 
 do_deploy() {
-	#Remove dynamic and gnu hash sections from elf file
+	#The default ELF file contains dynamic and gnu hash sections which the CCES elfloader cannot parse.  
+	#Using objcopy to remove those sections did not seem to have the intended effect
+	# so instead we keep only sections that we are interested in.
 	${OBJCOPY} -j .text -j .rodata -j .hash -j .dtb.init.rodata -j .data -j .got -j .got.plt -j .u_boot_list -j .rel.dyn ${B}/u-boot-${BOARD}
 	install ${B}/u-boot-${BOARD}.ldr ${DEPLOYDIR}/
 	install ${B}/u-boot-${BOARD} ${DEPLOYDIR}/

--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi.bb
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi.bb
@@ -37,6 +37,8 @@ do_install () {
 }
 
 do_deploy() {
+	#Remove dynamic and gnu hash sections from elf file
+	${OBJCOPY} -j .text -j .rodata -j .hash -j .dtb.init.rodata -j .data -j .got -j .got.plt -j .u_boot_list -j .rel.dyn ${B}/u-boot-${BOARD}
 	install ${B}/u-boot-${BOARD}.ldr ${DEPLOYDIR}/
 	install ${B}/u-boot-${BOARD} ${DEPLOYDIR}/
 	install ${B}/${INIT_PATH}/init-${BOARD}.elf ${DEPLOYDIR}/


### PR DESCRIPTION
The sections present in the elf file that CCES elfloader stumbles over has been removed as part of the deploy stage.  The resulting u-boot image boots and is accepted by CCES elfloader