### PR TITLE
u-boot-adi: dynamically set the name of the ldr tool

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi_2020.10.bb
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi_2020.10.bb
@@ -46,8 +46,8 @@ do_compile_prepend(){
 	cp ${LIBFDT_ENV_H_FILE} ${WORKDIR}/recipe-sysroot-native/usr/include/libfdt_env.h
 	cp ${LIBFDT_H_FILE} ${WORKDIR}/recipe-sysroot-native/usr/include/libfdt.h
 
-	#Add arm-poky-linux-gnueabi-ldr in to path
-	export PATH=$PATH:${WORKDIR}
+	#Make the ldr tool available to the build
+	cp ${WORKDIR}/arm-poky-linux-gnueabi-ldr ${RECIPE_SYSROOT_NATIVE}/usr/bin/${HOST_PREFIX}ldr
 }
 
 do_install () {


### PR DESCRIPTION
The name of the ldr binary assumes the user is using poky for their distro and
sets the PATH to include $WORKDIR. Adjust the name of the binary based on the
user's setup instead of assuming a specific distro; place the native binary in
a location where Yocto is already naturally looking for native binaries.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>