### PR TITLE
adsp-sc5xx-ramdisk: update packages installation into RD and fix FIT

### DIFF
--- a/meta-adi-adsp-sc5xx/classes/adsp-sc5xx-ramdisk.bbclass
+++ b/meta-adi-adsp-sc5xx/classes/adsp-sc5xx-ramdisk.bbclass
@@ -1,10 +1,10 @@
-inherit core-image extrausers adsp-sc5xx-compatible
+inherit core-image extrausers adsp-sc5xx-compatible nopackages
 
 SHARC_ALSA_BINARIES = "${@bb.utils.contains_any('DISTRO_FEATURES', 'adi_sharc_alsa_audio', 'sharc-audio', '', d)}"
 HYBRID_BINARIES = "${@bb.utils.contains_any('DISTRO_FEATURES', 'adi_hybrid_audio', 'hybrid-audio', '', d)}"
 LINUX_ONLY_BINARIES = "${@bb.utils.contains_any('DISTRO_FEATURES', 'linux_only_audio', 'rpmsg-echo-example', '', d)}"
 
-IMAGE_INSTALL = " \
+PACKAGE_INSTALL = " \
     busybox-watchdog-init \
     initramfs-init \
     busybox \
@@ -12,7 +12,7 @@ IMAGE_INSTALL = " \
     ${HYBRID_BINARIES} \
     ${LINUX_ONLY_BINARIES} \
 "
-
+INHIBIT_DEFAULT_DEPS = "1"
 DISTRO_FEATURES += " ram"
 IMAGE_FSTYPES = " cpio.xz cpio.gz"
 


### PR DESCRIPTION
image corruption

* Tests were done by using `adsp-sc5xx-minimal` image on `SC598` platform.
* Add the following line into your `conf/local.conf`
```
IMAGE_INSTALL:append = " perf strace" 
``` 
* The device boots properly.
```
root@adsp-sc598-som-ezkit:~# hostnamectl 
 Static hostname: adsp-sc598-som-ezkit
       Icon name: computer
      Machine ID: 64b62666631641e381d51dc8e917c99a
         Boot ID: 6dd7f5828d8f4d63a6babfa02c32991e
Operating System: Analog Devices Inc Reference Distro (glibc) 3.0.0 (kirkstone)
          Kernel: Linux 5.15.78-yocto-standard
    Architecture: arm64
root@adsp-sc598-som-ezkit:~#
```