### PR TITLE
Add evaluation disclaimer on booting text

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-core/base-files/base-files/issue
+++ b/meta-adi-adsp-sc5xx/recipes-core/base-files/base-files/issue
@@ -21,3 +21,12 @@
                  www.analog.com
               www.yoctoproject.org
      
+     ***************************************
+     ************* PLEASE NOTE *************
+     ***************************************
+     * This is an evaluation system with   *
+     * default username/password           *
+     ***************************************
+     ******* NOT FIT FOR PRODUCTION ********
+     ***************************************
+

--- a/meta-adi-adsp-sc5xx/recipes-core/base-files/base-files/issue.net
+++ b/meta-adi-adsp-sc5xx/recipes-core/base-files/base-files/issue.net
@@ -21,3 +21,12 @@
                  www.analog.com
               www.yoctoproject.org
      
+     ***************************************
+     ************* PLEASE NOTE *************
+     ***************************************
+     * This is an evaluation system with   *
+     * default username/password           *
+     ***************************************
+     ******* NOT FIT FOR PRODUCTION ********
+     ***************************************
+


### PR DESCRIPTION
The Linux for ADSP distro is provided as an evaluation build (for a range of evaluation boards). The root password is pre-shared and generally it has not been built with security in mind.

This adds a disclaimer to highlight that.