### PR TITLE
uboot SRCREV: updating source revision for uboot

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi_2023.04.bb
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi_2023.04.bb
@@ -2,7 +2,7 @@ inherit adsp-sc5xx-compatible
 
 require u-boot-adi.inc
 
-SRCREV = "19b81ea10b32ec365dcc6afa44cc675dd391c6aa"
+SRCREV = "cec1ef96097c6c407bf7d6abe014fdec94837801"
 
 UBOOT_INITIAL_ENV = ""
 


### PR DESCRIPTION
Updating SRCREV for uboot recipe

uboot now tries to detect the silicon version and the soc family of the board.