### PR TITLE
sc589-mini: Changing rfs erase block and padding

### DIFF
--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc589-mini.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc589-mini.conf
@@ -28,4 +28,4 @@ WKS_FILE = "adsp-sc5xx.wks.in"
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
 BOARD = "sc589-mini"
 
-EXTRA_IMAGECMD:jffs2 = "--pad=0x920000 --little-endian --eraseblock=0x8000 --no-cleanmarkers"
+EXTRA_IMAGECMD:jffs2 = "--pad=0x1AC0000 --little-endian --eraseblock=0x10000 --no-cleanmarkers"

--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi_2023.04.bb
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi_2023.04.bb
@@ -2,7 +2,7 @@ inherit adsp-sc5xx-compatible
 
 require u-boot-adi.inc
 
-SRCREV = "f7b14ad118478a4169348b81c5659bc4b99c795f"
+SRCREV = "377ef631447b716d5f4df52eb5e27dd9e1b3345a"
 
 UBOOT_INITIAL_ENV = ""
 

--- a/meta-adi-adsp-sc5xx/recipes-kernel/linux/linux-adi_5.15.bb
+++ b/meta-adi-adsp-sc5xx/recipes-kernel/linux/linux-adi_5.15.bb
@@ -14,7 +14,7 @@ PV = "5.15.78"
 LINUX_VERSION = "${PV}"
 
 KERNEL_BRANCH ?= "develop/yocto-3.1.0"
-SRCREV  = "376fa91e308afa51408be0f1561b15b7cfd7a69d"
+SRCREV  = "4dc3ccc04afd62073a138fb8edc3551af5ff08ea"
 
 # Include kernel configuration fragments
 SRC_URI:append = " \


### PR DESCRIPTION
Now aligns with linux and uboot modifications

