### PR TITLE
rootfs: Correcting jffs2 params for rfs creation

### DIFF
--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc573-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc573-ezkit.conf
@@ -28,4 +28,4 @@ WKS_FILE = "adsp-sc5xx.wks.in"
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
 BOARD = "sc573-ezkit"
 
-EXTRA_IMAGECMD:jffs2 = "--pad=0x920000 --little-endian --eraseblock=0x8000 --no-cleanmarkers"
+EXTRA_IMAGECMD:jffs2 = "--pad=0x920000 --little-endian --eraseblock=0x10000 --no-cleanmarkers"

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc584-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc584-ezkit.conf
@@ -24,4 +24,4 @@ IMAGE_FSTYPES = "tar.xz jffs2"
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
 BOARD = "sc584-ezkit"
 
-EXTRA_IMAGECMD:jffs2 = "--pad=0x920000 --little-endian --eraseblock=0x8000 --no-cleanmarkers"
+EXTRA_IMAGECMD:jffs2 = "--pad=0x920000 --little-endian --eraseblock=0x10000 --no-cleanmarkers"

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc589-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc589-ezkit.conf
@@ -28,4 +28,4 @@ WKS_FILE = "adsp-sc5xx.wks.in"
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
 BOARD = "sc589-ezkit"
 
-EXTRA_IMAGECMD:jffs2 = "--pad=0x920000 --little-endian --eraseblock=0x8000 --no-cleanmarkers"
+EXTRA_IMAGECMD:jffs2 = "--pad=0x920000 --little-endian --eraseblock=0x10000 --no-cleanmarkers"


### PR DESCRIPTION
Targeted platforms: SC584-ezkit, 573-ezkit and 589-ezkit

Changing the erase block size for rootfs from 32KB to 64KB. This allows the kernel to boot without any error messages.
This is applied for all boards with w25q128 chip. 


