### PR TITLE
Change BCODE for SC594 from '2' to '1'

### DIFF
--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
@@ -14,7 +14,7 @@ MACHINE_FEATURES:append = " spl"
 
 # Parameters for ADI LDR tool if a recipe needs them
 LDR_PROC = "SC594"
-LDR_BCODE ?= "2"
+LDR_BCODE ?= "1"
 
 MACHINE_EXTRA_RDEPENDS = "adsp-boot"
 


### PR DESCRIPTION
When leaving the position at '0', both spi and ospi boot modes are working. If switching to '1' (QSPI), U-Boot hangs at

```Shell
U-Boot SPL 2023.04 (Oct 31 2023 - 13:56:01 +0000)
ADI Boot Mode: 0x1 (QSPI Master)
Trying to boot from BOOTROM
```
Switching BCODE from '2' to '1' slows down the SPI operations to ensure maximum compatibility. The notable differences between the 2 are as follows:

- a normal read (0x03) as compared to a fast read(0x0b)
- lower clock for the SPI (the divider is set to 0xF, while no divider was previously, i.e, divider was set to 0x1)
- the Transmit and Receive FIFO buffers for the SPI are disabled

The root cause has not been identified yet, but this solved the issue at the expense of lower SPI clock frequencies in U-Boot. No other side-effects are observed