### PR TITLE
Adding patch for enabling developer options

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi.inc
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi.inc
@@ -28,6 +28,8 @@ SRC_URI += " \
 
 SRC_URI:append:adsp-sc598-som-ezkit = "${@' file://0001-sc598-som-enable-SDcard.patch' if bb.utils.to_boolean(d.getVar('ADSP_SC598_SDCARD')) else ''}"
 
+SRC_URI:append = "${@' file://0002-developer-mode-enable.patch' if bb.utils.to_boolean(d.getVar('DEVELOPER_MODE')) else '' }"
+
 LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
 

--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi/0002-developer-mode-enable.patch
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi/0002-developer-mode-enable.patch
@@ -1,0 +1,61 @@
+diff --git a/arch/arm/mach-sc5xx/spl.c b/arch/arm/mach-sc5xx/spl.c
+index 45a0b225d4..dd5a28107d 100644
+--- a/arch/arm/mach-sc5xx/spl.c
++++ b/arch/arm/mach-sc5xx/spl.c
+@@ -1,11 +1,13 @@
+ /* SPDX-License-Identifier: GPL-2.0-or-later */
+ /*
+- * (C) Copyright 2022 - Analog Devices, Inc.
++ * (C) Copyright 2023 - Analog Devices, Inc.
+  *
+  * Written and/or maintained by Timesys Corporation
++ * Modified by Analog Devices, Inc.
+  *
+  * Contact: Nathan Barrett-Morrison <nathan.morrison@timesys.com>
+  * Contact: Greg Malysa <greg.malysa@timesys.com>
++ * Contact: Utsav Agarwal <utsav.agarwal@analog.com>
+  */
+ 
+ #include <asm-generic/gpio.h>
+@@ -26,6 +28,7 @@ static u32 initramfs_len;
+ #endif
+ 
+ u32 bmode;
++#define BMODE_ADDR 0x82000000
+ 
+ int spl_start_uboot(void)
+ {
+@@ -68,6 +71,8 @@ void board_boot_order(u32 *spl_boot_list)
+ 	};
+ 
+ 	char *bmodeString = "unknown";
++	int i = 0;
++
+ 
+ 	bmode = (readl(pRCU_STAT) & BITM_RCU_STAT_BMODE) >> BITP_RCU_STAT_BMODE;
+ 
+@@ -131,10 +136,22 @@ void board_boot_order(u32 *spl_boot_list)
+ 	}
+ 
+ #else
++
++	bmode = *((unsigned int *) BMODE_ADDR) - 1;
++	printf("Entering Developer Mode...\n");
++	if ((ARRAY_SIZE(bmodes) <= bmode) || (0 >= bmode)) {
++		printf("Please enter a bootmode at 0x%08x via JTAG:\n",BMODE_ADDR);
++		for (i = 0; i < ARRAY_SIZE(bmodes); i++)
++			printf("[%d]	%s\n", i+1, bmodes[i]);
++		
++		bmode = 0; //allow continuing to load U-boot proper if needed
++	} else {
++		printf("Booting into %s\n", bmodes[bmode], bmode);
++	}
++
+ 	if (bmode == 0) {
+ 		printf("SPL execution has completed.  Please load U-Boot Proper via JTAG");
+-		while (1)
+-			;
++		while (1);
+ 	}
+ 
+ 	// Everything goes back to bootrom where we'll read table parameters and ask it


### PR DESCRIPTION
This allows switching between different boot methods by utilizing JTAG

In order to change the bootmode as required:

1. Define DEVELOPER_MODE in your conf/local.conf, set it to "1" and compile
2. Turn the dial to bootmode 0 and reset the board
3. load the SPL via gdb, which should now give some additional print statements
 ```
U-Boot SPL 2023.04 (Nov 09 2023 - 10:39:28 +0000)
ADI Boot Mode: 0x0 (JTAG/BOOTROM)
Entering Developer Mode...
Please enter a bootmode at 0x82000000 via JTAG:
[1]     JTAG/BOOTROM
[2]     QSPI Master
[3]     QSPI Slave
[4]     UART
[5]     LP0 Slave
[6]     OSPI
SPL execution has completed.  Please load U-Boot Proper via JTAG
```
Note that the address listed above is arbitrary and was chosen since Uboot was already using $loadaddr at the same location.
4. Now on GDB, stop the program and write to the memory location using the following command:
`set {int}0x82000000 = <bootmode>`
5. load the SPL again and it will boot into the requested mode (the following shows boot into QSPI Master):
```
U-Boot SPL 2023.04 (Nov 09 2023 - 10:39:28 +0000)
ADI Boot Mode: 0x0 (JTAG/BOOTROM)
Entering Developer Mode...
Booting into QSPI Master
Trying to boot from BOOTROM


U-Boot 2023.04 (Nov 09 2023 - 10:39:28 +0000)

CPU:   ADSP ADSP-SC594-0.0 (spi slave boot)
Detected Revision: 1.1
Model: ADI sc594-som-ezkit
DRAM:  992 MiB
Core:  120 devices, 19 uclasses, devicetree: embed
MMC:
Loading Environment from SPIFlash... Read ID via 1x SPI: 9d 5a 19
SF: Detected is25lx256 with page size 256 Bytes, erase size 128 KiB, total 32 MiB
OK
In:    serial@0x31003000
Out:   serial@0x31003000
Err:   serial@0x31003000
Net:   eth0: eth0
Error: eth1 address not set.

Hit any key to stop autoboot:  6
```