### PR TITLE
Correcting recipe format for linux kernel

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-kernel/linux/linux-adi_5.15.bb
+++ b/meta-adi-adsp-sc5xx/recipes-kernel/linux/linux-adi_5.15.bb
@@ -33,7 +33,7 @@ SRC_URI:append:adsp-sc589-mini = " file://feature/cfg/snd_mini.scc"
 
 SRC_URI:append:adsp-sc598-som-ezkit = "${@' file://0001-sc598-som-enable-SDcard.patch' if bb.utils.to_boolean(d.getVar('ADSP_SC598_SDCARD')) else ''}"
 
-SRC_URI:append:adsp-sc598-som-ezkit = "file://0001-SC598-fix-stmmac-dma-split-header-crash.patch"
+SRC_URI:append:adsp-sc598-som-ezkit = " file://0001-SC598-fix-stmmac-dma-split-header-crash.patch"
 
 do_install:append(){
 	rm -rf ${D}/lib/modules/5.15.78-yocto-standard/modules.builtin.modinfo


### PR DESCRIPTION
Corrects the formatting for including multiple patches for sc598