### PR TITLE
SC594: Reverting BCODE change for sc594

### DIFF
--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
@@ -14,7 +14,7 @@ MACHINE_FEATURES:append = " spl"
 
 # Parameters for ADI LDR tool if a recipe needs them
 LDR_PROC = "SC594"
-LDR_BCODE ?= "1"
+LDR_BCODE ?= "2"
 
 MACHINE_EXTRA_RDEPENDS = "adsp-boot"
 


### PR DESCRIPTION
Allows faster clock speeds, based on adjusted clock speed for spi in uboot.