### PR TITLE
rng-tools: disabling unsupported entropy source

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-extended/rng-tools/files/0001-Disable-RNDR-as-this-is-not-available-on-our-ARMv8.2.patch
+++ b/meta-adi-adsp-sc5xx/recipes-extended/rng-tools/files/0001-Disable-RNDR-as-this-is-not-available-on-our-ARMv8.2.patch
@@ -1,0 +1,40 @@
+From a4fae0e2dc955b587a601673ddcedd1a95068faf Mon Sep 17 00:00:00 2001
+From: Nathan Barrett-Morrison <nathan.morrison@timesys.com>
+Date: Fri, 5 May 2023 11:52:50 -0400
+Subject: [PATCH] Disable RNDR as this is not available on our ARMv8.2 platform
+
+---
+ Makefile.am  | 4 ----
+ configure.ac | 2 --
+ 2 files changed, 6 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index c303b11..6f938bc 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -23,10 +23,6 @@ if DARN
+ rngd_SOURCES	+= rngd_darn.c
+ endif
+ 
+-if RNDR
+-rngd_SOURCES	+= rngd_rndr.c
+-endif
+-
+ if JITTER
+ rngd_SOURCES	+= rngd_jitter.c
+ endif
+diff --git a/configure.ac b/configure.ac
+index 40008ca..6c74402 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -75,8 +75,6 @@ AS_IF([test $host_cpu = x86_64 || test $host_cpu = i686], [AC_DEFINE([HAVE_RDRAN
+ AM_CONDITIONAL([DARN], [test $host_cpu = powerpc64le])
+ AS_IF([test $host_cpu = powerpc64le], [AC_DEFINE([HAVE_DARN],1,[Enable DARN])],[])
+ 
+-AM_CONDITIONAL([RNDR], [test $host_cpu = aarch64])
+-AS_IF([test $host_cpu = aarch64], [AC_DEFINE([HAVE_RNDR],1,[Enable RNDR])],[])
+ AM_CONDITIONAL([JITTER], [false])
+ 
+ AC_ARG_ENABLE(jitterentropy,
+-- 
+2.30.2

--- a/meta-adi-adsp-sc5xx/recipes-extended/rng-tools/rng-tools_%.bbappend
+++ b/meta-adi-adsp-sc5xx/recipes-extended/rng-tools/rng-tools_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+#Disable RNDR, not available on our ARM64
+SRC_URI += "file://0001-Disable-RNDR-as-this-is-not-available-on-our-ARMv8.2.patch"
+
+#Disable jitter entropy generation/initialization (software based and takes too long)
+EXTRA_OECONF:append=" --disable-jitterentropy"


### PR DESCRIPTION
![image](https://github.com/analogdevicesinc/lnxdsp-adi-meta/assets/141642367/4549c284-b800-426c-bcce-f83627748e92)
Fixing entropy sources for rng-tools - now only uses supported hardware based source.