### PR TITLE
ldr recipe tweaks

### DIFF
--- a/meta-adi-adsp-sc5xx/classes/adsp-sc5xx.bbclass
+++ b/meta-adi-adsp-sc5xx/classes/adsp-sc5xx.bbclass
@@ -50,6 +50,7 @@ PASSWD_ROOT = "\$5\$j9T8zDE13LXUGyc6\$utDvGwFWR.kt/AKwwbHnXC14HJBqbcWwvLoDDLMQrc
 EXTRA_USERS_PARAMS = "usermod -p '${PASSWD_ROOT}' root;"
 
 TOOLCHAIN_HOST_TASK:append = " nativesdk-openocd-adi"
+TOOLCHAIN_HOST_TASK:append = " nativesdk-ldr-adi"
 
 IMAGE_FSTYPES:append = " tar.xz jffs2 "
 

--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/ldr-adi.bb
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/ldr-adi.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Analog Devices Loader Utility"
 LICENSE = "CLOSED"
 
-inherit autotools pkgconfig gettext native
+inherit autotools pkgconfig gettext
 
 LDR_GIT_URI ?= "git://github.com/analogdevicesinc/lnxdsp-arm-poky-linux-gnueabi-ldr.git"
 LDR_GIT_PROTOCOL ?= "https"
@@ -14,3 +14,5 @@ SRC_URI = " \
 ${LDR_GIT_URI};protocol=${LDR_GIT_PROTOCOL};branch=${LDR_GIT_BRANCH}"
 
 S = "${WORKDIR}/git/src/ldr"
+
+BBCLASSEXTEND += "native nativesdk"


### PR DESCRIPTION
This adds ldr to the SDK so we can build u-boot from the OE produced SDK.