### PR TITLE
Use hwrng as default entropy source

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-extended/rng-tools/rng-tools_%.bbappend
+++ b/meta-adi-adsp-sc5xx/recipes-extended/rng-tools/rng-tools_%.bbappend
@@ -5,3 +5,9 @@ SRC_URI += "file://0001-Disable-RNDR-as-this-is-not-available-on-our-ARMv8.2.pat
 
 #Disable jitter entropy generation/initialization (software based and takes too long)
 EXTRA_OECONF:append=" --disable-jitterentropy"
+
+do_install:append() {
+	sed -i \
+            -e 's/\$EXTRA_ARGS/$EXTRA_ARGS -x jitter/' \
+            ${D}${systemd_system_unitdir}/rngd.service
+}


### PR DESCRIPTION
Tested on SC589-mini. First few minutes after board boot high CPU usage by rngd service. Disables jitter as entropy source and instead using device random generator TRNG hardware, issue with high CPU usage not observed after board boots. 