### PR TITLE
SC594: Hotfix for SC594 L3 DDR memory overlap

### DIFF
--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
@@ -28,9 +28,9 @@ BASH_HAS_SPL = "${@bb.utils.contains_any('MACHINE_FEATURES', 'spl falcon', '1', 
 BASH_HAS_SPL_ONLY = "${@bb.utils.contains('MACHINE_FEATURES', 'spl', '1', '', d)}"
 BASH_HAS_FALCON_ONLY = "${@bb.utils.contains('MACHINE_FEATURES', 'falcon', '1', '', d)}"
 
-UBOOT_ENTRYPOINT = "0x80008000"
-UBOOT_LOADADDRESS = "0x80008000"
-UBOOT_DTBADDRESS = "0x80000000"
+UBOOT_ENTRYPOINT = "0xA3008000"
+UBOOT_LOADADDRESS = "0xA3008000"
+UBOOT_DTBADDRESS = "0xA3000000"
 
 KERNEL_DEVICETREE = "sc594-som-ezkit.dtb"
 


### PR DESCRIPTION
Resizing accessible memory range for ARM on sc594 such that it does not overlap with SHARC allocated address space