### PR TITLE
Fix SHARC-ALSA example.

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-kernel/linux/linux-adi/0003-Disable-sharc-n-_rpmsg-drivers-and-revert-RPMSG_ADI-.patch
+++ b/meta-adi-adsp-sc5xx/recipes-kernel/linux/linux-adi/0003-Disable-sharc-n-_rpmsg-drivers-and-revert-RPMSG_ADI-.patch
@@ -1,0 +1,65 @@
+From aa524dbd448f2789044b8e1b7264c3cd72ad53a3 Mon Sep 17 00:00:00 2001
+From: Oliver Gaskell <Oliver.Gaskell@analog.com>
+Date: Wed, 3 Jul 2024 16:29:50 +0100
+Subject: [PATCH] Disable sharc[n]_rpmsg drivers, and revert RPMSG_ADI to
+ RPMSG_VIRTIO
+
+---
+ arch/arm64/boot/dts/adi/sc598-som.dtsi       | 27 --------------------
+ arch/arm64/configs/sc598-som-ezkit_defconfig |  2 +-
+ 2 files changed, 1 insertion(+), 28 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/adi/sc598-som.dtsi b/arch/arm64/boot/dts/adi/sc598-som.dtsi
+index ecc58d904cd6..65b0f101ef92 100644
+--- a/arch/arm64/boot/dts/adi/sc598-som.dtsi
++++ b/arch/arm64/boot/dts/adi/sc598-som.dtsi
+@@ -102,33 +102,6 @@ sharc1: core2-rproc@0x28a40000 {
+ 			status = "okay";
+ 		};
+ 
+-		sharc0_rpmsg: core0-rpmsg@0x28240000 {
+-				status = "okay";
+-				compatible = "adi,rpmsg-SC598";
+-				core-id = <1>;
+-				adi,rcu = <&rcu>;
+-				adi,rsc-table = <&rsc_tbl0>;
+-				interrupts = <GIC_SPI 337 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
+-				adi,tru = <&tru>;
+-				adi,tru-master-id = <135>; /* trigger master SOFT4 */
+-				vdev-vring = <&vdev0vrings>;
+-				memory-region = <&vdev0buffer>;
+-		};
+-
+-		sharc1_rpmsg: core1-rpmsg@0x28a40000 {
+-				status = "okay";
+-				compatible = "adi,rpmsg-SC598";
+-				core-id = <2>;
+-				adi,rcu = <&rcu>;
+-				adi,rsc-table = <&rsc_tbl1>;
+-				interrupts = <GIC_SPI 337 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
+-				adi,tru = <&tru>;
+-				adi,tru-master-id = <136>; /* trigger master SOFT5 */
+-				vdev-vring = <&vdev1vrings>;
+-				memory-region = <&vdev1buffer>;
+-		};
+-
+-
+ 	};
+ 
+ };
+diff --git a/arch/arm64/configs/sc598-som-ezkit_defconfig b/arch/arm64/configs/sc598-som-ezkit_defconfig
+index 4380ef497418..b7ea7bab5dcb 100644
+--- a/arch/arm64/configs/sc598-som-ezkit_defconfig
++++ b/arch/arm64/configs/sc598-som-ezkit_defconfig
+@@ -295,7 +295,7 @@ CONFIG_REMOTEPROC=y
+ CONFIG_ADI_REMOTEPROC=y
+ CONFIG_RPMSG_CHAR=y
+ CONFIG_RPMSG_QCOM_GLINK_RPM=y
+-CONFIG_RPMSG_ADI=y
++CONFIG_RPMSG_VIRTIO=y
+ CONFIG_PM_DEVFREQ=y
+ CONFIG_DEVFREQ_GOV_SIMPLE_ONDEMAND=y
+ CONFIG_IIO=y
+-- 
+2.34.1
+

--- a/meta-adi-adsp-sc5xx/recipes-kernel/linux/sharc_audio.inc
+++ b/meta-adi-adsp-sc5xx/recipes-kernel/linux/sharc_audio.inc
@@ -6,6 +6,11 @@ SHARC_ALSA_PATCH = " \
 	file://0002-SC598-Enable-SHARC-ALSA-demo-disabling-most-linux-ba.patch \
 "
 
+SHARC_ALSA_WITHOUT_RPMSG = " \
+	${SHARC_ALSA_PATCH} \
+	file://0003-Disable-sharc-n-_rpmsg-drivers-and-revert-RPMSG_ADI-.patch \
+"
+
 SHARC_ALSA_PATCH_UBOOT = " \
 	${SHARC_ALSA_PATCH} \
 	file://0003-Disable-remoteproc.patch \
@@ -16,7 +21,7 @@ SRC_URI += " \
 "
 
 SRC_URI += " \
-	${@bb.utils.contains('DISTRO_FEATURES', 'adi_sharc_alsa_audio', '${SHARC_ALSA_PATCH}', '', d)} \
+	${@bb.utils.contains('DISTRO_FEATURES', 'adi_sharc_alsa_audio', '${SHARC_ALSA_WITHOUT_RPMSG}', '', d)} \
 "
 
 SRC_URI += " \


### PR DESCRIPTION
When attempting to use the SHARC-ALSA example, an error was thrown when starting up the SHARC core after loading the firmware. This was due to two drivers being present at the same time. Fixed this by disabling RPMsg, since it isn't actually used at all.