### PR TITLE
README: Fix codespell typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ chmod a+x ./bin/repo
 ./bin/repo sync
 ```
 
-Now, inside the project directory that was created in the previous step, a `bin` directory will be created and the `repo` tool will be downoaded to it. The tool will be instructed to download the various `lnxdsp` sources (including this repo) according to the `main` branch.
+Now, inside the project directory that was created in the previous step, a `bin` directory will be created and the `repo` tool will be downloaded to it. The tool will be instructed to download the various `lnxdsp` sources (including this repo) according to the `main` branch.
 
 What remains is picking a board to build for, e.g. the ADSP-SC598-SOM-EZKIT:
 ```Shell


### PR DESCRIPTION
Fix a small spelling mistake detected by codespell in the README "downoaded" -> "downloaded".