### PR TITLE
HOTFIX: Fix broken build for Rev E sc598 SOM

### DIFF
--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
@@ -22,6 +22,9 @@ UBOOT_DEF_SUFFIX := "${@bb.utils.contains('MACHINE_FEATURES', 'spl', '-spl', '',
 UBOOT_DEF_SUFFIX := "${@bb.utils.contains('MACHINE_FEATURES', 'falcon', '-falcon', '${UBOOT_DEF_SUFFIX}', d)}"
 UBOOT_MACHINE = "sc594-som-ezkit${UBOOT_DEF_SUFFIX}_defconfig"
 
+# Hardware(Carrier) Revision
+CRR_REV ?= "D"
+
 # use with -n "${BASH_HAS_SPL}" to test for spl build, which also includes falcon boot
 # or with -z to check for not spl build
 BASH_HAS_SPL = "${@bb.utils.contains_any('MACHINE_FEATURES', 'spl falcon', '1', '', d)}"

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc598-som-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc598-som-ezkit.conf
@@ -26,8 +26,8 @@ UBOOT_DEF_SUFFIX := "${@bb.utils.contains('MACHINE_FEATURES', 'falcon', '-falcon
 UBOOT_MACHINE = "sc598-som-ezkit${UBOOT_DEF_SUFFIX}_defconfig"
 
 # Hardware(SOM and Carrier) Revision
-SOM_REV = "D"
-CRR_REV = "D"
+SOM_REV ?= "D"
+CRR_REV ?= "D"
 
 # use with -n "${BASH_HAS_SPL}" to test for spl build, which also includes falcon boot
 # or with -z to check for not spl build


### PR DESCRIPTION
This commit was not included in the 3.1.2 release, which results in the SOM_REV being hardcoded for Rev D and the Rev E patch not being applied. 