### PR TITLE
sc5xx: Remove carrier revision from EZLITE conf files

### DIFF
--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezlite.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezlite.conf
@@ -22,9 +22,6 @@ UBOOT_DEF_SUFFIX := "${@bb.utils.contains('MACHINE_FEATURES', 'spl', '-spl', '',
 UBOOT_DEF_SUFFIX := "${@bb.utils.contains('MACHINE_FEATURES', 'falcon', '-falcon', '${UBOOT_DEF_SUFFIX}', d)}"
 UBOOT_MACHINE = "sc594-som-ezlite${UBOOT_DEF_SUFFIX}_defconfig"
 
-# Hardware(Carrier) Revision
-CRR_REV ?= "D"
-
 # use with -n "${BASH_HAS_SPL}" to test for spl build, which also includes falcon boot
 # or with -z to check for not spl build
 BASH_HAS_SPL = "${@bb.utils.contains_any('MACHINE_FEATURES', 'spl falcon', '1', '', d)}"

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc598-som-ezlite.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc598-som-ezlite.conf
@@ -25,9 +25,8 @@ UBOOT_DEF_SUFFIX := "${@bb.utils.contains('MACHINE_FEATURES', 'spl', '-spl', '',
 UBOOT_DEF_SUFFIX := "${@bb.utils.contains('MACHINE_FEATURES', 'falcon', '-falcon', '${UBOOT_DEF_SUFFIX}', d)}"
 UBOOT_MACHINE = "sc598-som-ezlite${UBOOT_DEF_SUFFIX}_defconfig"
 
-# Hardware(SOM and Carrier) Revision
+# Hardware(SOM) Revision
 SOM_REV ?= "D"
-CRR_REV ?= "D"
 
 # use with -n "${BASH_HAS_SPL}" to test for spl build, which also includes falcon boot
 # or with -z to check for not spl build


### PR DESCRIPTION
Remove the carrier revision from the .conf files for the EZLITE board. The EZLITE board only has one revision unlike the EZKIT which has multiple.