### PR TITLE
openocd: Update openocd recipe for 3.1.2

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-devtools/openocd/openocd-adi.bb
+++ b/meta-adi-adsp-sc5xx/recipes-devtools/openocd/openocd-adi.bb
@@ -6,16 +6,15 @@ RDEPENDS:${PN} = "libusb1"
 
 OPENOCD_GIT_URI ?= "git://github.com/analogdevicesinc/openocd.git"
 OPENOCD_GIT_PROTOCOL ?= "https"
-OPENOCD_BRANCH ?= "adi-main"
+OPENOCD_BRANCH ?= "release-0.12.0-1.1.2"
 
 SRC_URI = " \
 	${OPENOCD_GIT_URI};protocol=${OPENOCD_GIT_PROTOCOL};branch=${OPENOCD_BRANCH} \
-	file://0001-Fixup-build-error-by-splitting-dap_cmd_pool-into-dap.patch \
 "
 
-SRCREV = "f73da81abc674d60b91fa3cdfae6db69a3a9e385"
+SRCREV = "12eaf7e6c1ceffdbc4d97350e07e2e2bd07f4287"
 
-PV = "0.10+gitr${SRCPV}"
+PV = "0.12+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 inherit pkgconfig autotools-brokensep gettext
@@ -23,7 +22,7 @@ inherit pkgconfig autotools-brokensep gettext
 BBCLASSEXTEND += "native nativesdk"
 
 EXTRA_OECONF = "--disable-ftdi --disable-stlink --disable-ti-icdi --disable-ulink --disable-usb-blaster-2 --disable-ft232r \
-                --disable-vsllink --enable-jlink --disable-xds110 --disable-osbdm --disable-opendous --disable-aice \
+                --disable-vsllink --disable-jlink --disable-xds110 --disable-osbdm --disable-opendous --disable-aice \
                 --disable-usbprog --disable-rlink --disable-armjtagew --enable-maintainer-mode --enable-ice1000 --enable-ice2000 \
                 --enable-adi-dbgagent --disable-libusbmux"
 


### PR DESCRIPTION
Update the openocd recipe to use the release branch as the branch adi-main in the openocd repo does
not exist anymore.

The recipe has been updated to match the recipe used by 5.0.0, which has been identified by the openocd team as the closest release to the removed adi-main code.