### PR TITLE
docs: fix SC589 Mini OpenOCD target

### DIFF
--- a/docs/getting-started/data/sc589-mini-3.1.0.yaml
+++ b/docs/getting-started/data/sc589-mini-3.1.0.yaml
@@ -6,7 +6,7 @@ machine: adsp-sc589-mini
 machine_short: sc589-mini
 arch: cortexa5t2hf-neon
 gdb_prefix: arm-adi_glibc-linux-gnueabi
-openocd_target: adspsc57x
+openocd_target: adspsc58x
 ethernet_connector: J13
 som_revision: false
 sdk_machine_note: false

--- a/docs/getting-started/data/sc589-mini-3.1.1.yaml
+++ b/docs/getting-started/data/sc589-mini-3.1.1.yaml
@@ -6,7 +6,7 @@ machine: adsp-sc589-mini
 machine_short: sc589-mini
 arch: cortexa5t2hf-neon
 gdb_prefix: arm-adi_glibc-linux-gnueabi
-openocd_target: adspsc57x
+openocd_target: adspsc58x
 ethernet_connector: J13
 som_revision: false
 sdk_machine_note: false

--- a/docs/getting-started/data/sc589-mini-3.1.2.yaml
+++ b/docs/getting-started/data/sc589-mini-3.1.2.yaml
@@ -6,7 +6,7 @@ machine: adsp-sc589-mini
 machine_short: sc589-mini
 arch: cortexa5t2hf-neon
 gdb_prefix: arm-adi_glibc-linux-gnueabi
-openocd_target: adspsc57x
+openocd_target: adspsc58x
 ethernet_connector: J13
 som_revision: false
 sdk_machine_note: false

--- a/docs/getting-started/data/sc589-mini-5.0.0.yaml
+++ b/docs/getting-started/data/sc589-mini-5.0.0.yaml
@@ -6,7 +6,7 @@ machine: adsp-sc589-mini
 machine_short: sc589-mini
 arch: cortexa5t2hf-neon
 gdb_prefix: arm-adi_glibc-linux-gnueabi
-openocd_target: adspsc57x
+openocd_target: adspsc58x
 ethernet_connector: J13
 som_revision: false
 sdk_machine_note: false

--- a/docs/getting-started/data/sc589-mini-5.0.1.yaml
+++ b/docs/getting-started/data/sc589-mini-5.0.1.yaml
@@ -6,7 +6,7 @@ machine: adsp-sc589-mini
 machine_short: sc589-mini
 arch: cortexa5t2hf-neon
 gdb_prefix: arm-adi_glibc-linux-gnueabi
-openocd_target: adspsc57x
+openocd_target: adspsc58x
 ethernet_connector: J13
 som_revision: false
 sdk_machine_note: false


### PR DESCRIPTION
The SC589 Mini uses the SC58x OpenOCD target configuration. The generated getting-started docs previously used the SC57x target, which causes a JTAG TAP ID mismatch when connecting with ICE 1000/ICE 2000.

Update the SC589 Mini docs to use adspsc58x instead.