### PR TITLE
Add USB variable to setup-environment

### DIFF
--- a/meta-adi-adsp-sc5xx/recipes-adi/images/files/init
+++ b/meta-adi-adsp-sc5xx/recipes-adi/images/files/init
@@ -165,7 +165,7 @@ case "$MACHINE_MODEL" in
     ;;
 esac
 
-echo "Install U-Boot to USB"
+echo "======== USB Installer ========"
 echo
 echo "This will erase and program the USB."
 printf "Continue? [y/N]: "

--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi.inc
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi.inc
@@ -18,11 +18,19 @@ UBOOT_SOM = "${@bb.utils.contains('SOM_REV', 'D', '${UBOOT_SOM_FILE}', '', d)}"
 
 python() {
     d.setVar('SDCARD_PATCH', '')
+    d.setVar('USB_PATCH', '')
 
     if d.getVar('SOM_REV') != 'D':
         d.setVar('SDCARD_PATCH', ' file://0001-sc598-som-enable-SD-card-revE.patch')
     else:
         d.setVar('SDCARD_PATCH', ' file://0001-sc598-som-enable-SD-card.patch')
+
+    machine = d.getVar('MACHINE')
+    if machine in ('adsp-sc598-som-ezkit', 'adsp-sc594-som-ezkit'):
+        d.setVar('USB_PATCH', ' file://0001-Add-USB-support-for-sc594-and-sc598.patch file://0002-Disable-eth1-to-enable-EZKIT-USB.patch')
+    elif machine in ('adsp-sc598-som-ezlite', 'adsp-sc594-som-ezlite'):
+        d.setVar('USB_PATCH', ' file://0001-Add-USB-support-for-sc594-and-sc598.patch')
+
 }
 
 UBOOT_BRANCH ?= "adi-u-boot-2025.10.y"
@@ -41,8 +49,7 @@ SRC_URI += " \
 "
 
 SRC_URI:append:adsp-sc598-som-ezkit = "${@d.getVar('SDCARD_PATCH') if (bb.utils.to_boolean(d.getVar('ADSP_SC598_SDCARD'))) else ''}"
-SRC_URI:append:adsp-sc598-som-ezkit = "${@' file://0001-sc594-sc598-usb-support.patch' if bb.utils.to_boolean(d.getVar('ADSP_SC59X_USB')) else '' }"
-SRC_URI:append:adsp-sc594-som-ezkit = "${@' file://0001-sc594-sc598-usb-support.patch' if bb.utils.to_boolean(d.getVar('ADSP_SC59X_USB')) else '' }"
+SRC_URI:append = "${@d.getVar('USB_PATCH') if (bb.utils.to_boolean(d.getVar('ADSP_SC59X_USB'))) else ''}"
 
 SRC_URI:append = "${@' file://0002-developer-mode-enable.patch' if bb.utils.to_boolean(d.getVar('DEVELOPER_MODE')) else '' }"
 

--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi/0001-Add-USB-support-for-sc594-and-sc598.patch
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi/0001-Add-USB-support-for-sc594-and-sc598.patch
@@ -1,21 +1,18 @@
-From dbcbb38fa28193d90b487f01ac6ec5f218856df2 Mon Sep 17 00:00:00 2001
+From e945fa9cb73c1aa76b89e793ee1ce4598b11d39a Mon Sep 17 00:00:00 2001
 From: Caleb Ethridge <caleb.ethridge@analog.com>
-Date: Wed, 15 Apr 2026 09:51:21 -0400
-Subject: [PATCH] Add USB support for sc594 and sc598
+Date: Thu, 30 Apr 2026 12:40:32 -0400
+Subject: [PATCH 1/2] Add USB support for sc594 and sc598
 
-By default, the USB cannot be used in U-boot because
-it shares lines with the eth1. This patch allows the USB to be enabled
-by holding the eth1 in reset, and adds support for retries to allow
-additional chances for slower devices to be detected before reporting
-failure.
+This patch adds support for retries to allow additional chances
+for slower devices to be detected before reporting failure, and updates
+the nop-phy driver to support the PHY on the sc59x family.
 
 Signed-off-by: Caleb Ethridge <caleb.ethridge@analog.com>
 ---
- arch/arm/dts/sc59x.dtsi           |  1 +
- board/adi/carriers/somcrr_ezkit.c |  4 ++--
- common/usb_hub.c                  | 12 +++++++++---
- drivers/phy/nop-phy.c             |  8 +++++++-
- 4 files changed, 19 insertions(+), 6 deletions(-)
+ arch/arm/dts/sc59x.dtsi |  1 +
+ common/usb_hub.c        | 12 +++++++++---
+ drivers/phy/nop-phy.c   |  8 +++++++-
+ 3 files changed, 17 insertions(+), 4 deletions(-)
 
 diff --git a/arch/arm/dts/sc59x.dtsi b/arch/arm/dts/sc59x.dtsi
 index 64e5a1afc53..3916a463723 100644
@@ -29,22 +26,6 @@ index 64e5a1afc53..3916a463723 100644
  			status = "disabled";
  		};
  
-diff --git a/board/adi/carriers/somcrr_ezkit.c b/board/adi/carriers/somcrr_ezkit.c
-index 3cd5a6cd10b..adb2f3c96d2 100644
---- a/board/adi/carriers/somcrr_ezkit.c
-+++ b/board/adi/carriers/somcrr_ezkit.c
-@@ -14,9 +14,9 @@ void adi_somcrr_enable_ethernet(void)
- 	struct gpio_desc *gige_reset;
- 
- 	if (!gpio_hog_lookup_name("eth1-en", &eth1))
--		dm_gpio_set_value(eth1, 1);
-+		dm_gpio_set_value(eth1, 0);
- 	if (!gpio_hog_lookup_name("eth1-reset", &eth1_reset))
--		dm_gpio_set_value(eth1_reset, 0);
-+		dm_gpio_set_value(eth1_reset, 1);
- 	if (!gpio_hog_lookup_name("gige-reset", &gige_reset))
- 		dm_gpio_set_value(gige_reset, 0);
- }
 diff --git a/common/usb_hub.c b/common/usb_hub.c
 index 6a4bcec00bc..0742786987a 100644
 --- a/common/usb_hub.c

--- a/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi/0002-Disable-eth1-to-enable-EZKIT-USB.patch
+++ b/meta-adi-adsp-sc5xx/recipes-bsp/u-boot/u-boot-adi/0002-Disable-eth1-to-enable-EZKIT-USB.patch
@@ -1,0 +1,33 @@
+From 731e5d834b144f2ec852f07ac08cf8284d22da91 Mon Sep 17 00:00:00 2001
+From: Caleb Ethridge <caleb.ethridge@analog.com>
+Date: Thu, 30 Apr 2026 12:43:10 -0400
+Subject: [PATCH 2/2] Disable eth1 to enable EZKIT USB
+
+Disable the eth1 interface on the SC594 and SC598 EZKITs, as
+the eth1 lines are shared with the USB lines and will cause issues
+with the USB interface when enabled.
+
+Signed-off-by: Caleb Ethridge <caleb.ethridge@analog.com>
+---
+ board/adi/carriers/somcrr_ezkit.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/board/adi/carriers/somcrr_ezkit.c b/board/adi/carriers/somcrr_ezkit.c
+index 3cd5a6cd10b..adb2f3c96d2 100644
+--- a/board/adi/carriers/somcrr_ezkit.c
++++ b/board/adi/carriers/somcrr_ezkit.c
+@@ -14,9 +14,9 @@ void adi_somcrr_enable_ethernet(void)
+ 	struct gpio_desc *gige_reset;
+ 
+ 	if (!gpio_hog_lookup_name("eth1-en", &eth1))
+-		dm_gpio_set_value(eth1, 1);
++		dm_gpio_set_value(eth1, 0);
+ 	if (!gpio_hog_lookup_name("eth1-reset", &eth1_reset))
+-		dm_gpio_set_value(eth1_reset, 0);
++		dm_gpio_set_value(eth1_reset, 1);
+ 	if (!gpio_hog_lookup_name("gige-reset", &gige_reset))
+ 		dm_gpio_set_value(gige_reset, 0);
+ }
+-- 
+2.34.1
+

--- a/tools/setup-environment
+++ b/tools/setup-environment
@@ -275,6 +275,16 @@ EOF
 EOF
     fi
 
+if [[ "$MACHINE" == "adsp-sc598-som-ezkit" || "$MACHINE" == "adsp-sc598-som-ezlite" || "$MACHINE" == "adsp-sc594-som-ezkit" || "$MACHINE" == "adsp-sc594-som-ezlite" ]]; then
+        # Add the (disabled by default) USB option for SC598 and SC594 SOMs
+        cat >> "conf/local.conf" <<EOF
+# Enable USB
+# Uncomment the following line to enable USB support from U-boot and Linux kernel
+# ADSP_SC59X_USB = "1"
+
+EOF
+    fi
+
         # Add the (disabled by default) CMA kernel config options
         cat >> "conf/local.conf" <<EOF
 # Enable CMA


### PR DESCRIPTION
Adding the USB variable to setup-environment so it is included in the local.conf automatically and adding a script marker for the USB in the init script to help with running it with automated tools.