### PR TITLE
Clean Up Setting Up Host PC Page

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,8 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      base_path: ${{ steps.base-path.outputs.base_path }}
 
     steps:
+    - name: Set base_path
+      id: base-path
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.ref_name }}" == "main" ]]; then
+          echo "base_path=." >> "$GITHUB_OUTPUT"
+        else
+          echo "base_path=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+        fi
     - uses: analogdevicesinc/doctools/checkout@action
 
     - name: Install pip packages
@@ -48,3 +58,4 @@ jobs:
     - uses: analogdevicesinc/doctools/gh-pages-deploy@action
       with:
         name: html
+        path: ${{ needs.build-doc.outputs.base_path }}

--- a/docs/getting-started/Setting-Up-Your-Host-PC.rst
+++ b/docs/getting-started/Setting-Up-Your-Host-PC.rst
@@ -10,7 +10,7 @@ Installing Required Packages
 
 In order to build and deploy Linux to your ADSP-SC5xx development board you will need to install the following packages on your host PC.
 
-.. shell::
+.. code-block:: shell
 
    sudo apt-get update
    sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat libsdl1.2-dev xterm u-boot-tools openssl curl tftpd-hpa python3 zstd liblz4-tool
@@ -23,22 +23,26 @@ In order to communicate with the U-Boot bootloader, a UART connection must be ma
 
 On the host PC open a terminal and execute the following commands:
 
-.. shell::
+.. code-block:: shell
 
-   $ sudo apt-get install -y minicom
-   $ sudo minicom -s
+   sudo apt-get install -y minicom
+   sudo minicom -s
 
-               +-----[configuration]------+
-               | Filenames and paths      |
-               | File transfer protocols  |
-               | Serial port setup        |
-               | Modem and dialing        |
-               | Screen and keyboard      |
-               | Save setup as dfl        |
-               | Save setup as..          |
-               | Exit                     |
-               | Exit from Minicom        |
-               +--------------------------+
+.. code-block:: text
+
+   The minicom menu will appear as follows:
+
+   +-----[configuration]------+
+   | Filenames and paths      |
+   | File transfer protocols  |
+   | Serial port setup        |
+   | Modem and dialing        |
+   | Screen and keyboard      |
+   | Save setup as dfl        |
+   | Save setup as..          |
+   | Exit                     |
+   | Exit from Minicom        |
+   +--------------------------+
 
 
    # Select Serial port setup
@@ -61,9 +65,11 @@ Configure TFTP Service
 A TFTP server on the host is used to transfer images to the development board.
 Install and configure.
 
-.. shell::
+.. code-block:: shell
 
    sudo vi /etc/default/tftpd-hpa
+
+.. code-block:: text
 
    #Replace the existing file with the following
    TFTP_USERNAME="tftp"
@@ -72,7 +78,7 @@ Install and configure.
    TFTP_OPTIONS="--secure"
    #End of File
 
-.. shell::
+.. code-block:: shell
 
    sudo mkdir /tftpboot
    sudo chmod 777 /tftpboot
@@ -86,33 +92,33 @@ For NFS boot we use the Network File System which is stored in local Ubuntu Host
 
 First, create a directory to store the file system for the target:
 
-.. shell::
+.. code-block:: shell
 
    sudo mkdir /romfs/
    sudo chmod 777 /romfs/
 
 Then, install the required package:
 
-.. shell::
+.. code-block:: shell
 
    sudo apt-get install nfs-kernel-server
    sudo vi /etc/exports
 
 Add the following line:
 
-.. shell::
+.. code-block:: shell
 
    /romfs *(rw,sync,no_root_squash,no_subtree_check)
 
 Start the NFS server:
 
-.. shell::
+.. code-block:: shell
 
    sudo systemctl start nfs-kernel-server
 
 We can verify that the NFS service is running by executing:
 
-.. shell::
+.. code-block:: shell
 
    sudo systemctl status nfs-kernel-server
 
@@ -143,14 +149,14 @@ In order to allow OpenOCD to use the ICE debugger, we need to provide the user a
 
 On the host PC create a group called ``adiusb`` and add the user which will be accessing the ICE debugger to it. In this case we will be adding whichever user is currently logged into the session.
 
-.. shell::
+.. code-block:: shell
 
    sudo groupadd adiusb
    sudo usermod -a -G adiusb $USER
 
 We notify udev about permissions to provide this usergroup by adding a rule to it.
 
-.. shell::
+.. code-block:: shell
 
    sudo vi /etc/udev/rules.d/adi.rules
 


### PR DESCRIPTION
Cleaning up the "Setting Up Host PC" page as some of the blocks were missing the copy to clipboard button and a couple of the block were missing text entirely. Switched to using code-block directives to allow for easier copying and pasting of the commands.

Additionally, Jorge has update the deploy docs action so that the base path can be specified when deploying, so the workflow needs to be updated.