### PR TITLE
docs: Update deploy-docs.yml for new version of deploy action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,8 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      base_path: ${{ steps.base-path.outputs.base_path }}
 
     steps:
+    - name: Set base_path
+      id: base-path
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.ref_name }}" == "main" ]]; then
+          echo "base_path=." >> "$GITHUB_OUTPUT"
+        else
+          echo "base_path=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+        fi
     - uses: analogdevicesinc/doctools/checkout@action
 
     - name: Install pip packages
@@ -48,3 +58,4 @@ jobs:
     - uses: analogdevicesinc/doctools/gh-pages-deploy@action
       with:
         name: html
+        path: ${{ needs.build-doc.outputs.base_path }}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,3 +103,4 @@ Documentation
 ----
 
 .. centered:: **Copyright © 2025 Analog Devices, Inc. All rights reserved.**
+.. centered:: ** Test change test change test change **


### PR DESCRIPTION
The new version of the deploy action changes how the path for deployment is specified, allowing for a path to be passed as an argument to the action. Updating the workflow to reflect this change.