### PR TITLE
Change rootfs image type from UBIFS to UBI

### DIFF
--- a/meta-adi-adsp-sc5xx/classes/adsp-sc5xx.bbclass
+++ b/meta-adi-adsp-sc5xx/classes/adsp-sc5xx.bbclass
@@ -55,7 +55,10 @@ EXTRA_USERS_PARAMS = "usermod -p '${PASSWD_ROOT}' root;"
 TOOLCHAIN_HOST_TASK:append = " nativesdk-openocd-adi"
 TOOLCHAIN_HOST_TASK:append = " nativesdk-ldr-adi"
 
-IMAGE_FSTYPES:append = " tar.xz ubifs "
+IMAGE_FSTYPES:append = " tar.xz ubi ext4"
+
+UBI_VOLNAME = "rootfs"
+UBINIZE_ARGS = "-m 1 -p 65536 -s 1"
 
 #For some reason on poky-tiny, INIT_MANAGER="systemd" does not appear to work
 #For now, let's relink directly to systemd
@@ -95,9 +98,9 @@ do_create_programming_images(){
         cp ${DEPLOY_DIR_IMAGE}/fitImage ${PROG_DIR}/
     fi
 
-    # Copy rootfs.ubifs, rename to 'rootfs.ubifs'
-    if [ -f ${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.rootfs.ubifs ]; then
-        cp ${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.rootfs.ubifs ${PROG_DIR}/rootfs.ubifs
+    # Copy rootfs.ubi
+    if [ -f ${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.rootfs.ubi ]; then
+        cp ${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.rootfs.ubi ${PROG_DIR}/rootfs.ubi
     fi
 
     if [ -f ${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.rootfs.ext4 ]; then

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc573-ezlite.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc573-ezlite.conf
@@ -22,7 +22,7 @@ SERIAL_CONSOLES ?= "115200;ttySC0"
 MMC_BOOT_STAGE1 = "u-boot-spl.ldr"
 MMC_BOOT_STAGE2 = "u-boot.ldr"
 
-IMAGE_FSTYPES = "tar.xz ubifs wic.gz ext4"
+IMAGE_FSTYPES = "wic.gz"
 WKS_FILE = "adsp-sc5xx.wks.in"
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc589-mini.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc589-mini.conf
@@ -25,7 +25,7 @@ SERIAL_CONSOLES ?= "115200;ttySC0"
 MMC_BOOT_STAGE1 = "u-boot-spl.ldr"
 MMC_BOOT_STAGE2 = "u-boot.ldr"
 
-IMAGE_FSTYPES = "tar.xz ubifs wic.gz ext4"
+IMAGE_FSTYPES = "wic.gz"
 WKS_FILE = "adsp-sc5xx.wks.in"
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezkit.conf
@@ -40,8 +40,6 @@ KERNEL_DEVICETREE = "adi/sc594-som-ezkit.dtb"
 
 SERIAL_CONSOLES ?= "115200;ttySC0"
 
-IMAGE_FSTYPES = "tar.xz ubifs ext4"
-
 #Booting from OSPI (IS25LX256) -- 128KB eraseblock:
 #EXTRA_IMAGECMD:jffs2 = "--pad --little-endian --eraseblock=0x20000 --no-cleanmarkers"
 

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezlite.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc594-som-ezlite.conf
@@ -37,8 +37,6 @@ KERNEL_DEVICETREE = "adi/sc594-som-ezlite.dtb"
 
 SERIAL_CONSOLES ?= "115200;ttySC0"
 
-IMAGE_FSTYPES = "tar.xz ubifs ext4"
-
 #Booting from OSPI (IS25LX256) -- 128KB eraseblock:
 #EXTRA_IMAGECMD:jffs2 = "--pad --little-endian --eraseblock=0x20000 --no-cleanmarkers"
 

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc598-som-ezkit.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc598-som-ezkit.conf
@@ -44,7 +44,7 @@ KERNEL_DEVICETREE = "adi/sc598-som-ezkit.dtb"
 
 SERIAL_CONSOLES ?= "115200;ttySC0"
 
-IMAGE_FSTYPES = "tar.xz ubifs wic.gz ext4"
+IMAGE_FSTYPES = "wic.gz"
 WKS_FILE = "adsp-sc5xx.wks.in"
 
 MKUBIFS_ARGS = "-m 1 -e 65408 -c 1519"

--- a/meta-adi-adsp-sc5xx/conf/machine/adsp-sc598-som-ezlite.conf
+++ b/meta-adi-adsp-sc5xx/conf/machine/adsp-sc598-som-ezlite.conf
@@ -43,7 +43,7 @@ KERNEL_DEVICETREE = "adi/sc598-som-ezlite.dtb"
 
 SERIAL_CONSOLES ?= "115200;ttySC0"
 
-IMAGE_FSTYPES = "tar.xz ubifs wic.gz ext4"
+IMAGE_FSTYPES = "wic.gz"
 WKS_FILE = "adsp-sc5xx.wks.in"
 
 MKUBIFS_ARGS = "-m 1 -e 65408 -c 1519"

--- a/meta-adi-adsp-sc5xx/recipes-adi/images/adsp-sc5xx-full.bb
+++ b/meta-adi-adsp-sc5xx/recipes-adi/images/adsp-sc5xx-full.bb
@@ -7,7 +7,7 @@ do_image_wic[depends] += " \
         ${IMAGE_BASENAME}:do_image_ext4 \
 "
 
-IMAGE_FSTYPES:remove = "ubifs"
+IMAGE_FSTYPES:remove = "ubi"
 
 FILE_SYSTEM_TOOLS = "\
 	e2fsprogs \

--- a/meta-adi-adsp-sc5xx/recipes-adi/images/files/init
+++ b/meta-adi-adsp-sc5xx/recipes-adi/images/files/init
@@ -56,17 +56,8 @@ case "$ans" in
     printf "Install rootfs to mtd3? [y/N]: "
     read -r rootfs_ans
     if [ "$rootfs_ans" = "y" ] || [ "$rootfs_ans" = "Y" ]; then
-      echo "Formatting mtd3 as UBI..."
-      ubiformat /dev/mtd3 -y > /dev/null
-
-      echo "Attaching UBI device..."
-      ubiattach -m 3 -d 0 > /dev/null
-
-      echo "Creating UBI volume 'rootfs'..."
-      ubimkvol /dev/ubi0 -N rootfs -m > /dev/null
-
-      echo "Writing rootfs to UBI volume..."
-      ubiupdatevol /dev/ubi0_0 /usr/firmware/rootfs.ubifs > /dev/null
+      echo "Writing rootfs UBI image to mtd3..."
+      ubiformat /dev/mtd3 -f /usr/firmware/rootfs.ubi -y > /dev/null
     fi
 
     sync
@@ -87,17 +78,8 @@ case "$ans" in
     flash_erase /dev/mtd2 0 0
     flashcp /usr/firmware/fitImage /dev/mtd2
 
-    echo "Formatting mtd3 as UBI..."
-    ubiformat /dev/mtd3 -y > /dev/null
-
-    echo "Attaching UBI device..."
-    ubiattach -m 3 -d 0 > /dev/null
-
-    echo "Creating UBI volume 'rootfs'..."
-    ubimkvol /dev/ubi0 -N rootfs -m > /dev/null
-
-    echo "Writing rootfs to UBI volume..."
-    ubiupdatevol /dev/ubi0_0 /usr/firmware/rootfs.ubifs > /dev/null
+    echo "Writing rootfs UBI image to mtd3..."
+    ubiformat /dev/mtd3 -f /usr/firmware/rootfs.ubi -y > /dev/null
 
     sync
     echo "SPI install complete"


### PR DESCRIPTION
Currently Yocto create a UBI fs image for the rootfs, requiring that the SPI flash be formatted first as UBI and then copy the file system into the created volume. This also prevents direct flashing of the image through something like flashcp or sf write in U-Boot, which will cause boot failures as the file system doesn't have the necessary headers expected in the full UBI volume.

This changes the build to create a fully formed UBI image with the rootfs inside as a UBI fs, allowing the image to be directly copied into a partition in the SPI flash and booted.