### PR TITLE
.github/build: set umask

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,7 @@ jobs:
       - name: Build ${{ matrix.image }} for ${{ matrix.machine }}
         run: |
           cd "${YOCTO_WORKSPACE}"
+          umask 022
           source setup-environment -b build
           bitbake ${{ matrix.image }}
 


### PR DESCRIPTION
In hardened enviroments, the umask is set to a more restrictive value through the systemd UMask parameter , but can be adjusted at the execution level.