### PR TITLE
.github/llm: add llm reviews

### DIFF
--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -86,7 +86,17 @@ jobs:
           The Yocto meta layer is used in the production of toolchains, uboot images,
           kernel and filesystem for ADI ADSP reference boards (e.g. `adsp-sc598-som-ezkit`).
 
-          Your review should be based on the current Yocto documentation (./yocto-docs/documentation).
+          Your review should be based on the current Yocto documentation
+          (./yocto-docs/documentation) and focus on the metadata standards:
+
+          - Verify SRC_URI and ensure matching checksums.
+          - Validate the presence and accuracy of LIC_FILES_CHKSUM.
+          - Confirm that the version of any .bbappend file matches the base recipe it extends.
+          - Check LAYERSERIES_COMPAT settings, specifically validating against the scarthgap pin.
+
+          A must read is ./yocto-docs/documentation/bsp-guide/bsp.rst, focus on
+          good practices for bsp layers, and how to integrate linux kernel.
+
           The lnxdsp-adi-meta documentation at ./docs/ maybe out-of-date.
           Never says things you are unsure.
 
@@ -99,24 +109,20 @@ jobs:
 
           Do **not** review commits starting with "[TMP]", "[ADI]", "[CI]",
           they are not part of the series but to change the CI/CD or temporally change behaviour.
-          You **must** check the appropriate datasheets for devices drivers, always convert pdfs
-          before reading it, in particular, camelot-py is already installed.
 
-          Pre-converted (with docling), may be available at the git tree:
+          To confirm information against ADI datasheets, a sitemap with all
+          pdfs, including the datasheets, is available at:
+            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling/en-pdf-sitemap.xml
+
+          A version in markdown may be available at the git tree:
             https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling
 
           for example:
-            https://www.analog.com/media/en/technical-documentation/data-sheets/max17335.pdf
+            https://www.analog.com/media/en/technical-documentation/data-sheets/adsp-sc596-adsp-sc598.pdf
           can be fetched with:
-            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling/media/en/technical-documentation/data-sheets/max17335.md
+            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling/media/en/technical-documentation/data-sheets/adsp-sc596-adsp-sc598.md
 
-          If not available,
-          `python3 $CI_WORKTREE/ci/extract_register_map.py ./datasheet.pdf`
-          extract register maps from datasheets and should work on most cases.
-
-          A sitemap with all pdfs, including the datasheets, is available at:
-            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling/en-pdf-sitemap.xml
-            (mirror of https://www.analog.com/media/en/en-pdf-sitemap.xml)
+          To convert pdfs to markdown before reading, camelot-py is already installed.
 
           EOF
 

--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -136,7 +136,7 @@ jobs:
           Context: Certain files have been modified intentionally to act as markers for review.
           **Requirement:** When a file is modified in this set, you must review the full-file.
           Logic:
-          1. Identify files containing the `/* touch */` comment or minor placeholder changes.
+          1. Identify files containing the `# touch` comment or minor placeholder changes.
           2. Disregard the placeholder change itself.
           3. Analyze the entire content of that file.
           EOF

--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -92,7 +92,10 @@ jobs:
           - Verify SRC_URI and ensure matching checksums.
           - Validate the presence and accuracy of LIC_FILES_CHKSUM.
           - Confirm that the version of any .bbappend file matches the base recipe it extends.
-          - Check LAYERSERIES_COMPAT settings, specifically validating against the scarthgap pin.
+          - Check LAYERSERIES_COMPAT settings validating against the version Scarthgap (5.0)
+
+          The LAYERSERIES_COMPAT prevent a build from breaking due to incompatible syntax
+          changes between different versions of Yocto.
 
           A must read is ./yocto-docs/documentation/bsp-guide/bsp.rst, focus on
           good practices for bsp layers, and how to integrate linux kernel.

--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -1,0 +1,183 @@
+name: LLM Agent
+run-name: LLM run ${{ inputs.ref }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, tag, PR number, or SHA to checkout"
+        required: false
+        type: string
+      prompt:
+        description: "Prompt to use, overwrites the default"
+        required: false
+        type: string
+        default: ""
+      prompt-extra:
+        description: "Extra prompt to concatenate"
+        required: false
+        type: string
+        default: ""
+      model:
+        description: "Model size"
+        type: choice
+        options:
+        - small
+        - medium
+        - large
+      strategy:
+        description: "Review strategy"
+        type: choice
+        options:
+        - commit
+        - files
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ${{ github.ref }}
+      prompt:
+        required: false
+        type: string
+        default: ""
+      prompt-extra:
+        required: false
+        type: string
+        default: ""
+      model:
+        required: false
+        type: string
+        default: "medium"
+      strategy:
+        description: "Review strategy"
+        type: string
+        default: "commit"
+    secrets:
+      PORTKEY_API_KEY:
+        required: true
+
+jobs:
+  llm:
+    runs-on: ${{ vars.RUNNER != '' && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      checks: read
+      pull-requests: read
+
+    outputs:
+      pr: ${{ steps.llm.outputs.pr }}
+      comment: ${{ steps.llm.outputs.comment }}
+
+    steps:
+      - name: Prepare prompt
+        run: |
+          prompt_file=$(mktemp --suffix=.md)
+          echo "prompt_file=$prompt_file" >> "$GITHUB_ENV"
+
+          cat <<'EOF' > "$prompt_file"
+          ${{ inputs.prompt }}
+          EOF
+
+          grep -q '[^[:space:]]' "$prompt_file" || \
+          cat <<'EOF' > "$prompt_file"
+          # Run a deep lnxdsp-adi-meta (Yocto meta layer) analysis.
+
+          The Yocto meta layer is used in the production of toolchains, uboot images,
+          kernel and filesystem for ADI ADSP reference boards (e.g. `adsp-sc598-som-ezkit`).
+
+          Your review should be based on the current Yocto documentation (./yocto-docs/documentation).
+          The lnxdsp-adi-meta documentation at ./docs/ maybe out-of-date.
+          Never says things you are unsure.
+
+          You shall install pip packages to help you review, test and debug;
+          a venv is already active.
+          The virtual environment includes $venv_packages.
+          You shall upgrade/downgrade these packages if needed.
+          All build dependencies (listed in the ./ci/Containerfile) are already
+          installed.
+
+          Do **not** review commits starting with "[TMP]", "[ADI]", "[CI]",
+          they are not part of the series but to change the CI/CD or temporally change behaviour.
+          You **must** check the appropriate datasheets for devices drivers, always convert pdfs
+          before reading it, in particular, camelot-py is already installed.
+
+          Pre-converted (with docling), may be available at the git tree:
+            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling
+
+          for example:
+            https://www.analog.com/media/en/technical-documentation/data-sheets/max17335.pdf
+          can be fetched with:
+            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling/media/en/technical-documentation/data-sheets/max17335.md
+
+          If not available,
+          `python3 $CI_WORKTREE/ci/extract_register_map.py ./datasheet.pdf`
+          extract register maps from datasheets and should work on most cases.
+
+          A sitemap with all pdfs, including the datasheets, is available at:
+            https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/docling/en-pdf-sitemap.xml
+            (mirror of https://www.analog.com/media/en/en-pdf-sitemap.xml)
+
+          EOF
+
+          if [[ "${{ inputs.strategy }}" == "files" ]]; then
+            cat <<'EOF' >> "$prompt_file"
+          ## File Review Protocol
+
+          Context: Certain files have been modified intentionally to act as markers for review.
+          **Requirement:** When a file is modified in this set, you must review the full-file.
+          Logic:
+          1. Identify files containing the `/* touch */` comment or minor placeholder changes.
+          2. Disregard the placeholder change itself.
+          3. Analyze the entire content of that file.
+          EOF
+          fi
+
+          cat <<'EOF' >> "$prompt_file"
+          ${{ inputs.prompt-extra }}
+          EOF
+
+      - name: Prepare tools
+        shell: bash
+        run: |
+          py_venv="$(mktemp -d)"
+          echo "py_venv=$py_venv" >> "$GITHUB_ENV"
+
+          python3 -m venv $py_venv
+          source $py_venv/bin/activate
+          python3 -m ensurepip --upgrade
+          pip install adi-doctools camelot-py
+
+      - name: Get yocto docs
+        shell: bash
+        run: |
+          git clone https://git.yoctoproject.org/yocto-docs.git \
+            --branch scarthgap --depth 1 -- yocto-docs
+
+      - uses: analogdevicesinc/doctools/llm@action
+        id: llm
+        with:
+          ref: ${{ inputs.ref }}
+          model: ${{ inputs.model }}
+          prompt-file: ${{ env.prompt_file }}
+          api-key: ${{ secrets.PORTKEY_API_KEY }}
+          py-venv: ${{ env.py_venv }}
+          sh-source: ${{ env.sh_source }}
+
+      - name: Clean-up
+        if: always()
+        run: |
+          rm -f "$prompt_file"
+          rm -rf "$py_venv"
+
+  pr-comment:
+    runs-on: ubuntu-slim
+    needs: llm
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: analogdevicesinc/doctools/gh-pr-comment@action
+        with:
+          pr: ${{ needs.llm.outputs.pr }}
+          body: ${{ needs.llm.outputs.comment }}


### PR DESCRIPTION
Based on analogdevicesinc/linux/ci/.github/workflows/llm.yml, add a llm.yml dispatch workflow to run code reviews. The llm is instructed to read ./docs/ and yocto's
yocto-docs/documentation (hardcoded version scarthgap).