### PR TITLE
.github/build: include PR changes in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,12 @@ jobs:
           cd "${YOCTO_WORKSPACE}"
           ./bin/repo sync
 
+      - name: Checkout ref into sources/meta-adi
+        uses: actions/checkout@v7
+        with:
+          # Override yocto's revision="main"
+          path: ${{ env.YOCTO_WORKSPACE }}/sources/meta-adi
+
       - name: Setup build environment
         run: |
           cd "${YOCTO_WORKSPACE}"


### PR DESCRIPTION
main.xml in the manifest repository points to the latest commit on main in the adi-meta repository. Therefore builds triggered by a PR would build main and not the changes in the PR