### PR TITLE
.github/build: split build into composite action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ on:
       override-meta-adi:
         type: boolean
         default: false
+    secrets:
+      APP_CLIENT_ID:
+        required: false
+      APP_PRIVATE_KEY:
+        required: false
+
 
 permissions:
   contents: read
@@ -44,8 +50,26 @@ jobs:
   build:
     runs-on: ${{ vars.RUNNER != '' && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
     steps:
+      - uses: actions/create-github-app-token@v3
+        if: ${{ github.repository_owner == 'adi-innersource' }}
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_CLIENT_ID  }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY  }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            linux
+            u-boot
+            lnxdsp-adi-meta
+            lnxdsp-adi-security-meta
+            lnxdsp-repo-manifest
+            lnxdsp-scripts
+            openocd
+
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Build
         uses: ./actions/build
@@ -55,6 +79,7 @@ jobs:
           manifest: ${{ inputs.manifest }}
           manifest-repo: ${{ inputs.manifest-repo }}
           override-meta-adi: ${{ inputs.override-meta-adi }}
+          gh-token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Upload release archive to release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,17 +5,17 @@ on:
     inputs:
       machine:
         description: "Yocto machine"
-        default: adsp-sc598-som-ezkit
+        default: "adsp-sc598-som-ezkit"
       image:
         description: "Yocto image"
-        default: adsp-sc5xx-minimal
+        default: "adsp-sc5xx-minimal"
       manifest:
         description: "Manifest"
         default: main
-      manifest_repo:
+      manifest-repo:
         description: "Manifest repository"
         default: ""
-      override_meta_adi:
+      override-meta-adi:
         description: "Override sources/meta-adi with the checked-out ref"
         type: boolean
         default: false
@@ -30,10 +30,10 @@ on:
       manifest:
         type: string
         default: main
-      manifest_repo:
+      manifest-repo:
         type: string
         default: ""
-      override_meta_adi:
+      override-meta-adi:
         type: boolean
         default: false
 
@@ -43,119 +43,24 @@ permissions:
 jobs:
   build:
     runs-on: ${{ vars.RUNNER != '' && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
-
     steps:
-      - name: Setup build workspace
-        run: |
-          # Create ephemeral workspace directory for this run
-          WORKSPACE="${GITHUB_WORKSPACE}/yocto-build-${GITHUB_RUN_ID}-${{ inputs.machine }}-${{ inputs.image }}-${{ inputs.manifest }}"
-          mkdir -p "${WORKSPACE}"
+      - name: Checkout
+        uses: actions/checkout@v7
 
-          # Use known persistent cache path if mounted
-          [ -d "/cache" ] && YOCTO_CACHE_DIR="/cache/yocto" || YOCTO_CACHE_DIR="$(mktemp -dt yocto.XXX)"
-          YOCTO_DL_DIR="${YOCTO_CACHE_DIR}/downloads"
-          YOCTO_SSTATE_DIR="${YOCTO_CACHE_DIR}/sstate"
-          mkdir -p "${YOCTO_DL_DIR}"
-          mkdir -p "${YOCTO_SSTATE_DIR}"
-
-          # Save workspace path and cache dirs for subsequent steps
-          echo "YOCTO_WORKSPACE=${WORKSPACE}" >> $GITHUB_ENV
-          echo "YOCTO_DL_DIR=${YOCTO_DL_DIR}" >> $GITHUB_ENV
-          echo "YOCTO_SSTATE_DIR=${YOCTO_SSTATE_DIR}" >> $GITHUB_ENV
-
-      - name: Setup repo tool
-        run: |
-          cd "${YOCTO_WORKSPACE}"
-          mkdir -p bin
-          curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > ./bin/repo
-          chmod a+x ./bin/repo
-
-      - name: Initialize repo manifest
-        run: |
-          manifest_repo="${{ inputs.manifest_repo }}"
-          [[ -n "$manifest_repo" ]] || manifest_repo="https://github.com/${{ github.repository_owner }}/lnxdsp-repo-manifest.git"
-          cd "${YOCTO_WORKSPACE}"
-          ./bin/repo init \
-            -u "$manifest_repo" \
-            -m "${{ inputs.manifest }}.xml"
-
-      - name: Override meta-adi revision via local manifest
-        if: ${{ inputs.override_meta_adi }}
-        run: |
-          cd "${YOCTO_WORKSPACE}"
-          override_rev="${{ github.event.pull_request.head.sha || github.sha }}"
-          mkdir -p .repo/local_manifests
-          cat > .repo/local_manifests/meta-adi-override.xml <<EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <manifest>
-            <remote fetch="${{ github.server_url }}/${{ github.repository_owner }}" name="ci"/>
-            <extend-project name="lnxdsp-adi-meta" path="sources/meta-adi" remote="ci" revision="${override_rev}"/>
-          </manifest>
-          EOF
-
-      - name: Sync all sources
-        run: |
-          cd "${YOCTO_WORKSPACE}"
-          ./bin/repo sync
-
-      - name: Setup build environment
-        run: |
-          cd "${YOCTO_WORKSPACE}"
-          source setup-environment -m ${{ inputs.machine }}
-
-          # Configure for CI with persistent caches in runner's home directory
-          cat >> conf/local.conf <<EOF
-
-          # CI Build Configuration - use persistent caches from runner's home
-          DL_DIR = "${{ env.YOCTO_DL_DIR }}"
-          SSTATE_DIR = "${{ env.YOCTO_SSTATE_DIR }}"
-          EOF
-
-      - name: Build image
-        run: |
-          cd "${YOCTO_WORKSPACE}"
-          umask 022
-          source setup-environment -b build
-          bitbake ${{ inputs.image }}
-          bitbake ${{ inputs.image }} -c populate_sdk
-
-      - name: Set artifact name
-        run: |
-          ARTIFACT_NAME="images-${{ inputs.machine }}-${{ inputs.image }}"
-          [[ "${{ inputs.manifest }}" == "main" ]] || ARTIFACT_NAME="${ARTIFACT_NAME}-${{ inputs.manifest }}"
-          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
-
-      - name: Upload Yocto images
-        uses: actions/upload-artifact@v6
+      - name: Build
+        uses: ./actions/build
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ env.YOCTO_WORKSPACE }}/build/tmp/deploy/images/${{ inputs.machine }}
-
-      - name: Locate SDK installer
-        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
-        run: |
-          SDK_INSTALLER=$(ls "${YOCTO_WORKSPACE}/build/tmp/deploy/sdk/"*.sh | head -n1)
-          echo "SDK_INSTALLER=${SDK_INSTALLER}" >> $GITHUB_ENV
-
-      - name: Upload SDK installer as artifact
-        uses: actions/upload-artifact@v6
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        with:
-          name: sdk-${{ inputs.machine }}-${{ inputs.image }}
-          path: ${{ env.SDK_INSTALLER }}
-
-      - name: Archive output images directory
-        if: ${{ github.event_name == 'release' }}
-        run: |
-          cd "${YOCTO_WORKSPACE}"
-          tar -cJvf images-${{ inputs.machine }}-${{ inputs.image }}-${{ github.event.release.tag_name }}.tar.xz \
-            build/tmp/deploy/images/${{ inputs.machine }}/
+          machine: ${{ inputs.machine }}
+          image: ${{ inputs.image }}
+          manifest: ${{ inputs.manifest }}
+          manifest-repo: ${{ inputs.manifest-repo }}
+          override-meta-adi: ${{ inputs.override-meta-adi }}
 
       - name: Upload release archive to release
         uses: svenstaro/upload-release-action@v2
         if: ${{ github.event_name == 'release' }}
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ github.token }}
           file: ${{ env.YOCTO_WORKSPACE }}/images-${{ inputs.machine }}-${{ inputs.image }}-${{ github.event.release.tag_name }}.tar.xz
           tag: ${{ github.ref }}
 
@@ -163,6 +68,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         if: ${{ github.event_name == 'release' }}
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ github.token }}
           file: ${{ env.SDK_INSTALLER }}
           tag: ${{ github.ref }}

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -25,6 +25,9 @@ jobs:
           - main
 
     uses: ./.github/workflows/build.yml
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.TOKEN_GENERATOR_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.TOKEN_GENERATOR_APP_PRIVATE_KEY }}
     permissions:
       contents: read
     with:

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -12,9 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   build:
     strategy:
@@ -28,11 +25,10 @@ jobs:
           - main
 
     uses: ./.github/workflows/build.yml
-    secrets: inherit
     permissions:
       contents: read
     with:
       machine: ${{ matrix.machine }}
       image: ${{ matrix.image }}
       manifest: ${{ matrix.manifest }}
-      override_meta_adi: true
+      override-meta-adi: true

--- a/actions/build/action.yml
+++ b/actions/build/action.yml
@@ -1,0 +1,149 @@
+name: Build ADI Yocto artifacts
+
+inputs:
+  machine:
+    description: "Yocto machine"
+    default: adsp-sc598-som-ezkit
+  image:
+    description: "Yocto image"
+    default: adsp-sc5xx-minimal
+  manifest:
+    description: "Manifest"
+    default: main
+  manifest-repo:
+    description: "Manifest repository"
+    default: ""
+  override-meta-adi:
+    description: "Override sources/meta-adi with the checked-out ref"
+    default: 'false'
+  gh-token:
+    description: "GitHub token with access to all required repositories"
+    default: ${{ github.token }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set github token
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+      run: |
+        git config --global credential.helper 'store'
+        echo "https://x-access-token:${GH_TOKEN}@github.com" > ~/.git-credentials
+
+    - name: Setup build workspace
+      shell: bash
+      run: |
+        # Create ephemeral workspace directory for this run
+        WORKSPACE="${GITHUB_WORKSPACE}/yocto-build-${GITHUB_RUN_ID}-${{ inputs.machine }}-${{ inputs.image }}-${{ inputs.manifest }}"
+        mkdir -p "${WORKSPACE}"
+
+        # Use known persistent cache path if mounted
+        [ -d "/cache" ] && YOCTO_CACHE_DIR="/cache/yocto" || YOCTO_CACHE_DIR="$(mktemp -dt yocto.XXX)"
+        YOCTO_DL_DIR="${YOCTO_CACHE_DIR}/downloads"
+        YOCTO_SSTATE_DIR="${YOCTO_CACHE_DIR}/sstate"
+        mkdir -p "${YOCTO_DL_DIR}"
+        mkdir -p "${YOCTO_SSTATE_DIR}"
+
+        # Save workspace path and cache dirs for subsequent steps
+        echo "YOCTO_WORKSPACE=${WORKSPACE}" >> $GITHUB_ENV
+        echo "YOCTO_DL_DIR=${YOCTO_DL_DIR}" >> $GITHUB_ENV
+        echo "YOCTO_SSTATE_DIR=${YOCTO_SSTATE_DIR}" >> $GITHUB_ENV
+
+    - name: Setup repo tool
+      shell: bash
+      run: |
+        cd "${YOCTO_WORKSPACE}"
+        mkdir -p bin
+        curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > ./bin/repo
+        chmod a+x ./bin/repo
+
+    - name: Initialize repo manifest
+      shell: bash
+      run: |
+        manifest_repo="${{ inputs.manifest-repo }}"
+        [[ -n "$manifest_repo" ]] || manifest_repo="https://github.com/${{ github.repository_owner }}/lnxdsp-repo-manifest.git"
+        cd "${YOCTO_WORKSPACE}"
+        ./bin/repo init \
+          -u "$manifest_repo" \
+          -m "${{ inputs.manifest }}.xml"
+
+    - name: Override meta-adi revision via local manifest
+      if: ${{ inputs.override-meta-adi == 'true' }}
+      shell: bash
+      run: |
+        cd "${YOCTO_WORKSPACE}"
+        override_rev="${{ github.event.pull_request.head.sha || github.sha }}"
+        mkdir -p .repo/local_manifests
+        cat > .repo/local_manifests/meta-adi-override.xml <<EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <manifest>
+          <remote fetch="${{ github.server_url }}/${{ github.repository_owner }}" name="ci"/>
+          <extend-project name="lnxdsp-adi-meta" path="sources/meta-adi" remote="ci" revision="${override_rev}"/>
+        </manifest>
+        EOF
+
+    - name: Sync all sources
+      shell: bash
+      run: |
+        cd "${YOCTO_WORKSPACE}"
+        ./bin/repo sync
+
+    - name: Setup build environment
+      shell: bash
+      run: |
+        cd "${YOCTO_WORKSPACE}"
+        source setup-environment -m ${{ inputs.machine }}
+
+        # Configure for CI with persistent caches in runner's home directory
+        cat >> conf/local.conf <<EOF
+
+        # CI Build Configuration - use persistent caches from runner's home
+        DL_DIR = "${{ env.YOCTO_DL_DIR }}"
+        SSTATE_DIR = "${{ env.YOCTO_SSTATE_DIR }}"
+        EOF
+
+    - name: Build image
+      shell: bash
+      run: |
+        cd "${YOCTO_WORKSPACE}"
+        umask 022
+        source setup-environment -b build
+        bitbake ${{ inputs.image }}
+        bitbake ${{ inputs.image }} -c populate_sdk
+
+    - name: Set artifact name
+      shell: bash
+      run: |
+        ARTIFACT_NAME="images-${{ inputs.machine }}-${{ inputs.image }}"
+        [[ "${{ inputs.manifest }}" == "main" ]] || ARTIFACT_NAME="${ARTIFACT_NAME}-${{ inputs.manifest }}"
+        echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
+
+    - name: Upload Yocto images
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.YOCTO_WORKSPACE }}/build/tmp/deploy/images/${{ inputs.machine }}
+
+    - name: Locate SDK installer
+      if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+      shell: bash
+      run: |
+        SDK_INSTALLER=$(ls "${YOCTO_WORKSPACE}/build/tmp/deploy/sdk/"*.sh | head -n1)
+        echo "SDK_INSTALLER=${SDK_INSTALLER}" >> $GITHUB_ENV
+
+    - name: Upload SDK installer as artifact
+      uses: actions/upload-artifact@v6
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      with:
+        name: sdk-${{ inputs.machine }}-${{ inputs.image }}
+        path: ${{ env.SDK_INSTALLER }}
+
+    - name: Archive output images directory
+      if: ${{ github.event_name == 'release' }}
+      shell: bash
+      run: |
+        cd "${YOCTO_WORKSPACE}"
+        tar -cJvf images-${{ inputs.machine }}-${{ inputs.image }}-${{ github.event.release.tag_name }}.tar.xz \
+          build/tmp/deploy/images/${{ inputs.machine }}/
+


### PR DESCRIPTION
Tokens cannot be written to github output (at least on EMU) without being wiped; split the action into a composite, so users can provide an alternative token as an input.

Also sanitizes the shady release action to outside the build step