### PR TITLE
Support SBOM for older releases

### DIFF
--- a/.github/workflows/top-level-old-releases.yml
+++ b/.github/workflows/top-level-old-releases.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 5 * * 1' # 05:00 UTC every Monday
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'actions/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/actions/build/action.yml
+++ b/actions/build/action.yml
@@ -101,11 +101,22 @@ runs:
         # CI Build Configuration - use persistent caches from runner's home
         DL_DIR = "${{ env.YOCTO_DL_DIR }}"
         SSTATE_DIR = "${{ env.YOCTO_SSTATE_DIR }}"
+        EOF
 
-        # Instruct Yocto to generate an SPDX Software Bill of Materials (SBOM) for the image.
+        # Instruct Yocto to generate an SPDX Software Bill of Materials (SBOM)
+        # for the image, falling back to the older SPDX class if 3.0 isn't available.
+        if find "${YOCTO_WORKSPACE}/sources" -type f -name 'create-spdx-3.0.bbclass' | grep -q .; then
+          cat >> conf/local.conf <<EOF
+
         INHERIT:remove = "create-spdx"
         INHERIT += "create-spdx-3.0"
         EOF
+        else
+          cat >> conf/local.conf <<EOF
+
+        INHERIT += "create-spdx"
+        EOF
+        fi
 
     - name: Build image
       shell: bash
@@ -135,8 +146,10 @@ runs:
       with:
         name: ${{ env.ARTIFACT_NAME }}.sbom
         path: |
-          ${{ env.YOCTO_WORKSPACE }}/build/tmp/deploy/images/${{ inputs.machine }}/${{ inputs.image }}-${{ inputs.machine }}.rootfs.spdx.json
+          ${{ env.YOCTO_WORKSPACE }}/build/tmp/deploy/images/${{ inputs.machine }}/${{ inputs.image }}-${{ inputs.machine }}.rootfs.spdx*
           ${{ env.YOCTO_WORKSPACE }}/build/tmp/deploy/spdx/
+          !${{ env.YOCTO_WORKSPACE }}/build/tmp/deploy/spdx/**/by-namespace/**
+          !${{ env.YOCTO_WORKSPACE }}/build/tmp/deploy/spdx/**/by-hash/**
 
     - name: Locate SDK installer
       if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
The older release used older versions of Yocto that did not have the SPDX 3.0 version. Added support for the SBOM for the older release by allowing a fallback to the older versions of the SPDX tool if the 3..0 recipe isn't available.