### PR TITLE
.github/build: Fallback to home cache path

### DIFF
--- a/actions/build/action.yml
+++ b/actions/build/action.yml
@@ -39,7 +39,7 @@ runs:
         mkdir -p "${WORKSPACE}"
 
         # Use known persistent cache path if mounted
-        [ -d "/cache" ] && YOCTO_CACHE_DIR="/cache/yocto" || YOCTO_CACHE_DIR="$(mktemp -dt yocto.XXX)"
+        [ -d "/cache" ] && YOCTO_CACHE_DIR="/cache/yocto" || YOCTO_CACHE_DIR="${GITHUB_WORKSPACE}/yocto-cache"
         YOCTO_DL_DIR="${YOCTO_CACHE_DIR}/downloads"
         YOCTO_SSTATE_DIR="${YOCTO_CACHE_DIR}/sstate"
         mkdir -p "${YOCTO_DL_DIR}"
@@ -173,3 +173,8 @@ runs:
         tar -cJvf images-${{ inputs.machine }}-${{ inputs.image }}-${{ github.event.release.tag_name }}.tar.xz \
           build/tmp/deploy/images/${{ inputs.machine }}/
 
+    - name: Clean up build
+      if: always()
+      shell: bash
+      run: |
+        [[ -n "${YOCTO_WORKSPACE}" ]] && rm -rf "${YOCTO_WORKSPACE}"


### PR DESCRIPTION
If /cache is not available, fallback to $GITHUB_WORKSPACE/yocto-cache, to still persist during the lifespan of the systemd service that owns the github runner. Also clean-up the distribution build directory on job conclusion, since they are unique per job.