### PR TITLE
.github: Remove cron schedule from top-level workflows

### DIFF
--- a/.github/workflows/top-level-old-releases.yml
+++ b/.github/workflows/top-level-old-releases.yml
@@ -2,8 +2,6 @@ name: Build ADI Yocto artifacts (old releases)
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 5 * * 1' # 05:00 UTC every Monday
   pull_request:
     paths:
       - '.github/**'

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -8,8 +8,6 @@ on:
       - "main"
   release:
     types: [published]
-  schedule:
-    - cron: '0 5 * * 1' # 05:00 UTC every Monday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
The same idea as: https://github.com/analogdevicesinc/br2-external/pull/55